### PR TITLE
chore(deps): bump use-mask-input from 3.5.0 to 3.12.0

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -51,7 +51,7 @@
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10",
         "tw-animate-css": "^1.3.4",
-        "use-mask-input": "^3.5.0",
+        "use-mask-input": "^3.12.0",
         "zod": "^3.25.67",
         "zustand": "^5.0.5"
       },
@@ -7917,16 +7917,37 @@
       }
     },
     "node_modules/use-mask-input": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/use-mask-input/-/use-mask-input-3.7.4.tgz",
-      "integrity": "sha512-/9kzCCJmxhwX21yjt83azSAPq7U+XQlnYRNx+LXhw9MlTv62HnG+GY6K4YivQd8m6ATxuJUeeuKDL0k+F9JVag==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/use-mask-input/-/use-mask-input-3.12.0.tgz",
+      "integrity": "sha512-S4i86Wg2USgRoYBslWfwie7lUz/6baUfI6su6atKAFM6STkipND2N1IGehHQFshGmwcHXCscbi+KZWSBHHfBEg==",
+      "license": "MIT",
       "engines": {
         "node": ">=16",
         "npm": ">=7"
       },
       "peerDependencies": {
+        "antd": ">=5",
         "react": ">=17",
-        "react-dom": ">=17"
+        "react-dom": ">=17",
+        "vee-validate": ">=4",
+        "vue": ">=3.4"
+      },
+      "peerDependenciesMeta": {
+        "antd": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "vee-validate": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sidecar": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -56,7 +56,7 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10",
     "tw-animate-css": "^1.3.4",
-    "use-mask-input": "^3.5.0",
+    "use-mask-input": "^3.12.0",
     "zod": "^3.25.67",
     "zustand": "^5.0.5"
   },


### PR DESCRIPTION
Bumps `use-mask-input` from `^3.5.0` to `^3.12.0` in `ui/`, and refreshes `ui/package-lock.json` (which currently resolves 3.7.4).

## Why

The main reason is bundle size. In 3.10.1 the library stopped importing Inputmask through its UMD entrypoint and started importing the ESM sources instead, which drops the legacy polyfill code from the build. I measured it on this repo with `npm run build`:

| | raw | gzip |
|---|---|---|
| `data-table` chunk before (3.7.4) | 302.2 kB | 89.9 kB |
| `data-table` chunk after (3.12.0) | 270.1 kB | 80.3 kB |
| total `dist/assets/*.js` before | 1510.5 kB | 474.3 kB |
| total `dist/assets/*.js` after | 1478.4 kB | 464.7 kB |

So about 32 kB raw and 9.6 kB gzip off the chunk that `pool-form.tsx` pulls in.

The other fixes between 3.7.4 and 3.12.0 that could matter here:

- 3.11.1 removes `maxLength` from an element before applying a mask. A `maxlength` at or below the masked length used to reject every keystroke, because the dots and `_` placeholders count toward the limit even though nobody typed them. The IP inputs in `pool-form.tsx` don't set `maxLength` today, so this is only relevant if one gets added later.
- 3.11.1 also fixes react-hook-form fields with a predefined value swallowing the first select-all + delete.
- 3.8.0 fixes masked inputs going stale after `reset()` in react-hook-form.
- 3.10.3 tightens the TypeScript types around the masked element.

Nothing in the range is a breaking change. The `withMask('ip', {...})` calls in `pool-form.tsx` work unchanged. The new optional `vue` / `vee-validate` / `antd` peers in 3.12.0 are all marked optional, so npm does not try to install them.

## Verification

```
cd ui && npm ci && npm run build
```

Build passes, no type errors, no new warnings.

## One thing I noticed

`ui/pnpm-lock.yaml` still pins `use-mask-input@3.5.0`, and CI has used npm since 6239fd9. That lockfile has been drifting from `package-lock.json` for a while. I left it alone here rather than commit a regenerated file you don't build from, but you may want to delete it.

## Disclosure

I maintain `use-mask-input`. I found this repo while looking at who still installs the older versions. Happy to close this if you'd rather bump on your own schedule, and equally happy to split the version bump from the lockfile refresh if that's easier to review.
